### PR TITLE
Updated tracker.js to show calendar for only nutrient tracker page

### DIFF
--- a/client/src/pages/Tracker.js
+++ b/client/src/pages/Tracker.js
@@ -24,7 +24,7 @@ const Tracker = ({ authProps }) => {
           handleTabUpdate={setSelectedTab}
           selectedTab={selectedTab}
           comps={
-            selectedTab !== "Food History" && (
+            selectedTab === "Nutrient Tracker" && (
               <div className="flex flex-row items-center">
                 <img
                   src="https://img.icons8.com/ios/50/000000/calendar--v1.png"


### PR DESCRIPTION
Instead of showing calendar for both nutrient tracker and nutrient advice (!== "Food History"), we flipped the conditional statement here to ONLY show the calendar if the selected tab is === "Nutrient Tracker". (Thus not showing calendar for Nutrient Advice AND Food History)